### PR TITLE
Various block break adjustments

### DIFF
--- a/assets/blocks/bars/CopperBar.block
+++ b/assets/blocks/bars/CopperBar.block
@@ -1,7 +1,7 @@
 {
     "categories": ["mineral"],
-    "hardness": 18,
-    "mass": 100,
+    "hardness": 22,
+    "mass": 150,
     "sounds": "CoreAssets:stone",
     "tile": "CoreAssets:CopperBar"
 }

--- a/assets/blocks/bars/DiamondBar.block
+++ b/assets/blocks/bars/DiamondBar.block
@@ -1,7 +1,7 @@
 {
     "categories": ["mineral"],
-    "hardness": 18,
-    "mass": 100,
+    "hardness": 22,
+    "mass": 150,
     "sounds": "CoreAssets:stone",
     "tile": "CoreAssets:DiamondBar"
 }

--- a/assets/blocks/bars/GoldBar.block
+++ b/assets/blocks/bars/GoldBar.block
@@ -1,7 +1,7 @@
 {
     "categories": ["mineral"],
-    "hardness": 18,
-    "mass": 100,
+    "hardness": 22,
+    "mass": 150,
     "sounds": "CoreAssets:stone",
     "tile": "CoreAssets:GoldBar"
 }

--- a/assets/blocks/bars/IronBar.block
+++ b/assets/blocks/bars/IronBar.block
@@ -1,7 +1,7 @@
 {
     "categories": ["mineral"],
-    "hardness": 18,
-    "mass": 100,
+    "hardness": 22,
+    "mass": 150,
     "sounds": "CoreAssets:stone",
     "tile": "CoreAssets:IronBar"
 }

--- a/assets/blocks/flora/cacti/Cactus.block
+++ b/assets/blocks/flora/cacti/Cactus.block
@@ -10,5 +10,7 @@
         "top": "CoreAssets:CactusTop",
         "bottom": "CoreAssets:CactusBottom"
     },
+    "hardness": 6,
+    "mass": 40,
     "translucent": true
 }

--- a/assets/blocks/templates/rock.block
+++ b/assets/blocks/templates/rock.block
@@ -1,7 +1,7 @@
 {
     "template": true,
     "categories": ["rock"],
-    "hardness": 12,
+    "hardness": 14,
     "mass": 100,
     "sounds": "CoreAssets:stone"
 }

--- a/assets/blocks/templates/wood.block
+++ b/assets/blocks/templates/wood.block
@@ -1,7 +1,7 @@
 {
     "template": true,
     "categories": ["wood"],
-    "hardness": 12,
+    "hardness": 10,
     "mass": 50,
     "sounds": "CoreAssets:wood"
 }

--- a/assets/prefabs/damageTypes/axeDamage.prefab
+++ b/assets/prefabs/damageTypes/axeDamage.prefab
@@ -2,7 +2,7 @@
     "parent": "engine:physicalDamage",
     "blockDamageModifier": {
         "materialDamageMultiplier": {
-            "wood": 2
+            "wood": 3
         }
     }
 }

--- a/assets/prefabs/damageTypes/pickaxeDamage.prefab
+++ b/assets/prefabs/damageTypes/pickaxeDamage.prefab
@@ -2,8 +2,8 @@
     "parent": "engine:physicalDamage",
     "blockDamageModifier": {
         "materialDamageMultiplier": {
-            "rock": 2,
-            "mineral": 2
+            "rock": 3,
+            "mineral": 3
         }
     }
 }

--- a/assets/prefabs/damageTypes/shovelDamage.prefab
+++ b/assets/prefabs/damageTypes/shovelDamage.prefab
@@ -2,7 +2,7 @@
     "parent": "engine:physicalDamage",
     "blockDamageModifier": {
         "materialDamageMultiplier": {
-            "soil": 2
+            "soil": 3
         }
     }
 }


### PR DESCRIPTION
Adjusts various block & tool levels to better balance block breaking times.

<h3>All Changes</h3>

- Increased block break time and mass of all mineral blocks.
- Increased block break time of cactus, and add axe damage boost.
- Slightly increased block break time of all stone materials.
- Slightly decreased block break time of all wood materials.
- Slightly buffed all tier 1 tools.